### PR TITLE
Adding utility function to get the latest build details

### DIFF
--- a/env.yaml.template
+++ b/env.yaml.template
@@ -53,3 +53,9 @@ openstack:
     region_name: <REGION>
     user_domain_name: <DOMAIN NAME>
     username: <USERNAME>
+#----------------Builds Required------------------------
+oc_builds:
+    ocp_version: 4.11.0
+    os_type: <OS_TYPE>
+    build_type: <BUILD_TYPE>
+

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,5 +1,12 @@
 """RHCS-System-test Utility module."""
+import re
+from urllib.request import urlopen
+import logging
+
+import requests
 from yaml import dump, safe_load
+
+log = logging.getLogger(__file__)
 
 
 def get_config(file_name="env.yaml"):
@@ -20,3 +27,38 @@ def get_kubeconfig(name="qe-hive"):
     with open(filename, "w") as _file:
         _file.write(dump(content))
     return filename
+
+
+def get_oc_builds():
+    """
+    This will return the latest build urls
+    args:
+        ocp_version : str accepted values : 4.11.0,4.12.0
+        os_type : str accepted values : linux mac windows
+        build_type : str accpeted values : nightly , ci
+    return:
+        {"client" : client_url , "installer": installer_url}
+    """
+    try:
+        config = get_config()
+        ocp_version = config["oc_builds"]["ocp_version"]
+        os_type = config["oc_builds"]["os_type"]
+        build_type = config["oc_builds"]["build_type"]
+        url = f"https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/{ocp_version}-0.{build_type}/latest"
+        data = requests.get(url, verify=False)
+        downloadURL = data.json()["downloadURL"]
+        log.info(downloadURL)
+        html = urlopen(downloadURL)
+        text = html.read()
+        plaintext = text.decode("utf8")
+        links = re.findall("href=[\"'](.*?)[\"']", plaintext)
+        log.info(links)
+        client_url = [i for i in links if f"openshift-client-{os_type}" in i]
+        installer_url = [i for i in links if f"openshift-install-{os_type}" in i]
+        return {
+            "client": f"{downloadURL}/{client_url[0]}",
+            "installer": f"{downloadURL}/{installer_url[0]}",
+        }
+    except:
+        log.error("Unable to fetch the build details")
+        return None


### PR DESCRIPTION

Adding utility function to get the latest build details
This will return the latest build URLs 
    args:
        ocp_version : str accepted values : 4.11.0,4.12.0
        os_type : str accepted values : linux mac windows
        build_type : str accpeted values : nightly , ci
    return:
        {"client" : client_url , "installer": installer_url}

Signed-off-by: Amarnath K <amk@amk.remote.csb>